### PR TITLE
Returning existing instances when multimethods are redefined instead of raising an exception.

### DIFF
--- a/multimethods.py
+++ b/multimethods.py
@@ -21,13 +21,15 @@ Default = DefaultMethod()
 class MultiMethod(object):
     instances = {}
 
+    def __new__(cls, name, dispatchfn):
+        if name in cls.instances:
+            return cls.instances[name]
+        else:
+            return object.__new__(cls, name, dispatchfn)
+
     def __init__(self, name, dispatchfn):
         if not callable(dispatchfn):
             raise TypeError('dispatchfn must be callable')
-
-        if name in self.__class__.instances:
-            raise Exception("A multimethod '%s' already exists, "
-                            "redeclaring it would wreak havoc" % name)
 
         self.dispatchfn = dispatchfn
         self.methods = {}


### PR DESCRIPTION
I was running into an issue with a module being imported multiple times and redefining the multimethod. I'm not sure this is the right solution—returning the existing instance, then re-assigning all the methods—since it creates the opportunity for hard-to-track-down bugs if one uses the same name as a multimethod that is defined in an imported module.

Now that I've talked myself out of it, thoughts?
