### PR TITLE
Added module-based namespacing.

### DIFF
--- a/multimethods.py
+++ b/multimethods.py
@@ -33,7 +33,7 @@ class MultiMethod(object):
         self.methods = {}
         self.__name__ = name
 
-        identifier = '{0}.{1}'.format(dispatchfn.__module__, name)
+        identifier = '%s.%s' % (dispatchfn.__module__, name)
         self.__class__.instances[identifier] = self
 
     def __call__(self, *args, **kwds):
@@ -70,7 +70,7 @@ def method(dispatchval):
         The multimethod is determined by taking the method's name up to the last occurence
         of '__', e.g. function foo_bar__zig will become a method on the foo_bar multimethod.'''
 
-        identifier = '{0}.{1}'.format(func.__module__, func.__name__)
+        identifier = '%s.%s' % (func.__module__, func.__name__)
 
         try:
             multim = MultiMethod.instances[identifier]

--- a/multimethods.py
+++ b/multimethods.py
@@ -32,7 +32,9 @@ class MultiMethod(object):
         self.dispatchfn = dispatchfn
         self.methods = {}
         self.__name__ = name
-        self.__class__.instances[name] = self
+
+        identifier = '{0}.{1}'.format(dispatchfn.__module__, name)
+        self.__class__.instances[identifier] = self
 
     def __call__(self, *args, **kwds):
         dv = self.dispatchfn(*args, **kwds)
@@ -68,8 +70,10 @@ def method(dispatchval):
         The multimethod is determined by taking the method's name up to the last occurence
         of '__', e.g. function foo_bar__zig will become a method on the foo_bar multimethod.'''
 
+        identifier = '{0}.{1}'.format(func.__module__, func.__name__)
+
         try:
-            multim = MultiMethod.instances[func.__name__]
+            multim = MultiMethod.instances[identifier]
         except KeyError:
             raise KeyError("Multimethod '%s' not found; it must exist before methods can be added")
 

--- a/multimethods.py
+++ b/multimethods.py
@@ -21,7 +21,9 @@ Default = DefaultMethod()
 class MultiMethod(object):
     instances = {}
 
-    def __init__(self, name, dispatchfn):
+    def __init__(self, name, dispatchfn, ns=None):
+        name = '%s.%s' % (ns or dispatchfn.__module__, name)
+
         if not callable(dispatchfn):
             raise TypeError('dispatchfn must be callable')
 
@@ -33,8 +35,7 @@ class MultiMethod(object):
         self.methods = {}
         self.__name__ = name
 
-        identifier = '%s.%s' % (dispatchfn.__module__, name)
-        self.__class__.instances[identifier] = self
+        self.__class__.instances[name] = self
 
     def __call__(self, *args, **kwds):
         dv = self.dispatchfn(*args, **kwds)
@@ -62,7 +63,7 @@ class MultiMethod(object):
         return "<MultiMethod '%s'>" % self.__name__
 
 
-def method(dispatchval):
+def method(dispatchval, ns=None):
     def method_decorator(func):
         '''Decorator which registers a function as a new method of a like-named multimethod,
         keyed by dispatchval.
@@ -70,7 +71,7 @@ def method(dispatchval):
         The multimethod is determined by taking the method's name up to the last occurence
         of '__', e.g. function foo_bar__zig will become a method on the foo_bar multimethod.'''
 
-        identifier = '%s.%s' % (func.__module__, func.__name__)
+        identifier = '%s.%s' % (ns or func.__module__, func.__name__)
 
         try:
             multim = MultiMethod.instances[identifier]

--- a/multimethods.py
+++ b/multimethods.py
@@ -21,8 +21,8 @@ Default = DefaultMethod()
 class MultiMethod(object):
     instances = {}
 
-    def __init__(self, name, dispatchfn, ns=None):
-        name = '%s.%s' % (ns or dispatchfn.__module__, name)
+    def __init__(self, name, dispatchfn, ns):
+        name = '%s.%s' % (ns, name)
 
         if not callable(dispatchfn):
             raise TypeError('dispatchfn must be callable')
@@ -62,7 +62,7 @@ class MultiMethod(object):
         return "<MultiMethod '%s'>" % self.__name__
 
 
-def method(dispatchval, ns=None):
+def method(dispatchval, ns):
     def method_decorator(func):
         '''Decorator which registers a function as a new method of a like-named multimethod,
         keyed by dispatchval.
@@ -70,12 +70,12 @@ def method(dispatchval, ns=None):
         The multimethod is determined by taking the method's name up to the last occurence
         of '__', e.g. function foo_bar__zig will become a method on the foo_bar multimethod.'''
 
-        name = '%s.%s' % (ns or func.__module__, func.__name__)
+        name = '%s.%s' % (ns, func.__name__)
 
         try:
             multim = MultiMethod.instances[name]
         except KeyError:
-            raise KeyError("Multimethod '%s' not found; it must exist before methods can be added")
+            raise KeyError("Multimethod '%s' not found; it must exist before methods can be added" % name)
 
         multim.addmethod(func, dispatchval)
 

--- a/multimethods.py
+++ b/multimethods.py
@@ -34,7 +34,6 @@ class MultiMethod(object):
         self.dispatchfn = dispatchfn
         self.methods = {}
         self.__name__ = name
-
         self.__class__.instances[name] = self
 
     def __call__(self, *args, **kwds):
@@ -71,10 +70,10 @@ def method(dispatchval, ns=None):
         The multimethod is determined by taking the method's name up to the last occurence
         of '__', e.g. function foo_bar__zig will become a method on the foo_bar multimethod.'''
 
-        identifier = '%s.%s' % (ns or func.__module__, func.__name__)
+        name = '%s.%s' % (ns or func.__module__, func.__name__)
 
         try:
-            multim = MultiMethod.instances[identifier]
+            multim = MultiMethod.instances[name]
         except KeyError:
             raise KeyError("Multimethod '%s' not found; it must exist before methods can be added")
 

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,19 @@
+import unittest
+
+from multimethods import MultiMethod, method
+
+
+class NamespaceTests(unittest.TestCase):
+    def test_definition(self):
+        mm = MultiMethod('definition', lambda value: value)
+        assert MultiMethod.instances.get('tests.definition'), "namespace is not 'tests'"
+
+    def test_installed_methods(self):
+        MultiMethod('installing', lambda value: value)
+
+        try:
+            @method(1)
+            def installing(value):
+                pass
+        except KeyError:
+            self.fail('not installing multimethods within namespace')

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ from multimethods import MultiMethod, method
 
 class NamespaceTests(unittest.TestCase):
     def test_definition(self):
-        mm = MultiMethod('definition', lambda value: value)
+        MultiMethod('definition', lambda value: value)
         assert MultiMethod.instances.get('tests.definition'), "namespace is not 'tests'"
 
     def test_installed_methods(self):
@@ -17,3 +17,17 @@ class NamespaceTests(unittest.TestCase):
                 pass
         except KeyError:
             self.fail('not installing multimethods within namespace')
+
+    def test_overriding(self):
+        MultiMethod('overriding', lambda value: value, ns='overridden')
+        assert MultiMethod.instances.get('overridden.overriding'), 'namespace cannot be overridden'
+
+    def test_overriding_installed(self):
+        MultiMethod('installed.overriding', lambda value: value)
+
+        try:
+            @method(1)
+            def installing(value):
+                pass
+        except KeyError:
+            self.fail('namespace cannot be overridden for methods')

--- a/tests.py
+++ b/tests.py
@@ -4,30 +4,31 @@ from multimethods import MultiMethod, method
 
 
 class NamespaceTests(unittest.TestCase):
-    def test_definition(self):
-        MultiMethod('definition', lambda value: value)
-        assert MultiMethod.instances.get('tests.definition'), "namespace is not 'tests'"
+    def test_definition_ns_required(self):
+        self.assertRaises(TypeError, MultiMethod, 'definition', lambda value: value)
 
-    def test_installed_methods(self):
-        MultiMethod('installing', lambda value: value)
+    def test_decorator_ns_required(self):
+        MultiMethod('decorator', lambda value: value, ns='custom')
 
         try:
             @method(1)
+            def decorator(value):
+                pass
+        except TypeError:
+            pass
+        else:
+            self.fail('method decorator does not require namespace')
+
+    def test_definition(self):
+        MultiMethod('definition', lambda value: value, ns='custom')
+        assert MultiMethod.instances.get('custom.definition'), "namespace is not 'custom'"
+
+    def test_installed_methods(self):
+        MultiMethod('installing', lambda value: value, ns='custom')
+
+        try:
+            @method(1, ns='custom')
             def installing(value):
                 pass
         except KeyError:
             self.fail('not installing multimethods within namespace')
-
-    def test_overriding(self):
-        MultiMethod('overriding', lambda value: value, ns='overridden')
-        assert MultiMethod.instances.get('overridden.overriding'), 'namespace cannot be overridden'
-
-    def test_overriding_installed(self):
-        MultiMethod('installed.overriding', lambda value: value)
-
-        try:
-            @method(1)
-            def installing(value):
-                pass
-        except KeyError:
-            self.fail('namespace cannot be overridden for methods')


### PR DESCRIPTION
Here's a simple implementation that just uses the module of the dispatch function. It does constrain the dispatch function and all the methods to be defined within the same module, which may be a problem in some scenarios.

Alternatively, there could be an optional keyword argument to override a default namespacing:

```
frobz = MultiMethod('frobz', dispatch_fn, namespace='myproject')

@method('bla', namespace='myproject')
def frobz(x):
    ...
```

This is no more concise than [your example](https://github.com/danwerner/multimethods/pull/2#issuecomment-3437271), but it does have your existing conciseness if module-based namespacing is acceptable.
